### PR TITLE
Correction to translation of EnumStrings in rich_types.rdoctest

### DIFF
--- a/hobo_fields/test/rich_types.rdoctest
+++ b/hobo_fields/test/rich_types.rdoctest
@@ -339,10 +339,13 @@ Sometimes it's nice to have a proper type name. Here's one way you might go abou
 Named EnumString's may be translated.   Here is an example fr.yml:
 
     fr:
-      article/statuses:
+      article/statuss:
         draft: "esquisse"
         approved: "approuvé"
         published: "publiés"
+
+(Note that in this case, the field name 'status' is pluralized, but very simply by adding an 's', not an 'es'
+as would be gramatically correct.)
 
 Alternatively, the translations may be supplied in ruby:
 


### PR DESCRIPTION
In Hobo's <input> tag definition for EnumString, Hobo simply tacks on an "s" to pluralize the field name:

```
    [I18n.t("activerecord.attributes.#{this_parent.class.to_s.downcase}/#{this_field}s.#{v}",
      :default => default),
    v]
```

For the example shown in the documentation, "statuses" was not correct. Hobo actually looks for "statuss", oddly enough. 

Tim
